### PR TITLE
Control high priority block num when pick recover blocks

### DIFF
--- a/src/flags.cc
+++ b/src/flags.cc
@@ -19,6 +19,9 @@ DEFINE_int32(nameserver_log_level, 4, "Nameserver log level");
 DEFINE_string(nameserver_warninglog, "./wflog", "Warning log file");
 DEFINE_int32(nameserver_safemode_time, 120, "Nameserver leave safemode time in ms");
 DEFINE_int32(recover_speed, 100, "max num of block to recover for one chunkserver");
+DEFINE_int32(priority_recover_high_watermark, 60, "max num of block to recover with high priority for one chunkserver");
+DEFINE_int32(priority_recover_low_watermark, 30, "min num of block to recover with high priority for one chunkserver");
+DEFINE_int32(priority_recover_threshold, 300, "threshold of block to recover with high priority");
 DEFINE_int32(recover_timeout, 180, "Recover timeout for one chunkserver");
 DEFINE_bool(clean_redundancy, false, "Clean redundant replica");
 


### PR DESCRIPTION
#201 
设置两个不同的watermark以及一个threshold
当所有high priority的block数超threshold时，对每个cs，让其尽量多的选择high priority block，但是不能超过high watermark
当所有high priority的block数低于threshold时，尽量让这些block分散，不过，仍保持每个cs上的数目不低于low watermark
当确定了high priority的数目后，剩余的quota分配给low priority的block