### PR TITLE
nameserver update incomplete block meta

### DIFF
--- a/src/nameserver/block_mapping.cc
+++ b/src/nameserver/block_mapping.cc
@@ -292,7 +292,6 @@ bool BlockMapping::UpdateIncompleteBlock(NSBlock* nsblock,
             block_version, block_size);
         nsblock->version = block_version;
         nsblock->block_size = block_size;
-        //TODO update namespace
         *need_sync_meta = true;
         file_name->append(nsblock->file_name);
     } else if (block_version < nsblock->version) {
@@ -307,6 +306,7 @@ bool BlockMapping::UpdateIncompleteBlock(NSBlock* nsblock,
                 nsblock->version, nsblock->block_size);
             nsblock->version = block_version;
             nsblock->block_size = block_size;
+            //TODO update meta here?
         } else {
             if (inc_replica.empty()) {
                 SetState(nsblock, kNotInRecover);

--- a/src/nameserver/block_mapping.h
+++ b/src/nameserver/block_mapping.h
@@ -29,8 +29,10 @@ struct NSBlock {
     RecoverStat recover_stat;
     std::set<int32_t> incomplete_replica;
     std::string file_name;
+    int64_t parent_entry_id;
     NSBlock();
-    NSBlock(int64_t block_id, int32_t replica, int64_t version, int64_t size, const std::string name);
+    NSBlock(int64_t block_id, int32_t replica, int64_t version,
+            int64_t size, const std::string name, int64_t eid);
     bool operator<(const NSBlock &b) const {
         return (this->replica.size() >= b.replica.size());
     }
@@ -65,9 +67,9 @@ public:
     void AddNewBlock(int64_t block_id, int32_t replica,
                      int64_t version, int64_t block_size,
                      const std::vector<int32_t>* init_replicas,
-                     const std::string& file_name);
+                     const std::string& file_name, int64_t entry_id);
     bool UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
-                         int64_t block_version, bool* need_sync_meta, std::string* file_name);
+                         int64_t block_version, bool* need_sync_meta);
     void RemoveBlocksForFile(const FileInfo& file_info);
     void RemoveBlock(int64_t block_id);
     void DealWithDeadNode(int32_t cs_id, const std::set<int64_t>& blocks);
@@ -103,8 +105,7 @@ private:
     bool UpdateNormalBlock(NSBlock* nsblock, int32_t cs_id, int64_t block_size,
                            int64_t block_version);
     bool UpdateIncompleteBlock(NSBlock* nsblock,int32_t cs_id, int64_t block_size,
-                               int64_t block_version,
-                               bool* need_sync_meta, std::string* file_name);
+                               int64_t block_version, bool* need_sync_meta);
 private:
     Mutex mu_;
     ThreadPool* thread_pool_;

--- a/src/nameserver/block_mapping.h
+++ b/src/nameserver/block_mapping.h
@@ -67,7 +67,7 @@ public:
                      const std::vector<int32_t>* init_replicas,
                      const std::string& file_name);
     bool UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
-                         int64_t block_version);
+                         int64_t block_version, bool* need_sync_meta, std::string* file_name);
     void RemoveBlocksForFile(const FileInfo& file_info);
     void RemoveBlock(int64_t block_id);
     void DealWithDeadNode(int32_t cs_id, const std::set<int64_t>& blocks);
@@ -103,7 +103,8 @@ private:
     bool UpdateNormalBlock(NSBlock* nsblock, int32_t cs_id, int64_t block_size,
                            int64_t block_version);
     bool UpdateIncompleteBlock(NSBlock* nsblock,int32_t cs_id, int64_t block_size,
-                               int64_t block_version);
+                               int64_t block_version,
+                               bool* need_sync_meta, std::string* file_name);
 private:
     Mutex mu_;
     ThreadPool* thread_pool_;

--- a/src/nameserver/block_mapping.h
+++ b/src/nameserver/block_mapping.h
@@ -28,8 +28,9 @@ struct NSBlock {
     uint32_t expect_replica_num;
     RecoverStat recover_stat;
     std::set<int32_t> incomplete_replica;
+    std::string file_name;
     NSBlock();
-    NSBlock(int64_t block_id, int32_t replica, int64_t version, int64_t size);
+    NSBlock(int64_t block_id, int32_t replica, int64_t version, int64_t size, const std::string name);
     bool operator<(const NSBlock &b) const {
         return (this->replica.size() >= b.replica.size());
     }
@@ -63,7 +64,8 @@ public:
     bool ChangeReplicaNum(int64_t block_id, int32_t replica_num);
     void AddNewBlock(int64_t block_id, int32_t replica,
                      int64_t version, int64_t block_size,
-                     const std::vector<int32_t>* init_replicas);
+                     const std::vector<int32_t>* init_replicas,
+                     const std::string& file_name);
     bool UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
                          int64_t block_version);
     void RemoveBlocksForFile(const FileInfo& file_info);

--- a/src/nameserver/block_mapping_manager.cc
+++ b/src/nameserver/block_mapping_manager.cc
@@ -47,9 +47,10 @@ bool BlockMappingManager::ChangeReplicaNum(int64_t block_id, int32_t replica_num
 
 void BlockMappingManager::AddNewBlock(int64_t block_id, int32_t replica,
                  int64_t version, int64_t block_size,
-                 const std::vector<int32_t>* init_replicas) {
+                 const std::vector<int32_t>* init_replicas,
+                 const std::string& file_name) {
     int32_t bucket_offset = GetBucketOffset(block_id);
-    block_mapping_[bucket_offset]->AddNewBlock(block_id, replica, version, block_size, init_replicas);
+    block_mapping_[bucket_offset]->AddNewBlock(block_id, replica, version, block_size, init_replicas, file_name);
 }
 
 bool BlockMappingManager::UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,

--- a/src/nameserver/block_mapping_manager.cc
+++ b/src/nameserver/block_mapping_manager.cc
@@ -48,17 +48,18 @@ bool BlockMappingManager::ChangeReplicaNum(int64_t block_id, int32_t replica_num
 void BlockMappingManager::AddNewBlock(int64_t block_id, int32_t replica,
                  int64_t version, int64_t block_size,
                  const std::vector<int32_t>* init_replicas,
-                 const std::string& file_name) {
+                 const std::string& file_name, int64_t entry_id) {
     int32_t bucket_offset = GetBucketOffset(block_id);
-    block_mapping_[bucket_offset]->AddNewBlock(block_id, replica, version, block_size, init_replicas, file_name);
+    block_mapping_[bucket_offset]->AddNewBlock(block_id, replica, version,
+                                               block_size, init_replicas, file_name, entry_id);
 }
 
 bool BlockMappingManager::UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
-                     int64_t block_version, bool* need_sync_meta, std::string* file_name) {
+                                          int64_t block_version, bool* need_sync_meta) {
     int32_t bucket_offset = GetBucketOffset(block_id);
     return block_mapping_[bucket_offset]->UpdateBlockInfo(block_id, server_id,
                                                           block_size, block_version,
-                                                          need_sync_meta, file_name);
+                                                          need_sync_meta);
 }
 
 void BlockMappingManager::RemoveBlocksForFile(const FileInfo& file_info) {

--- a/src/nameserver/block_mapping_manager.cc
+++ b/src/nameserver/block_mapping_manager.cc
@@ -54,9 +54,11 @@ void BlockMappingManager::AddNewBlock(int64_t block_id, int32_t replica,
 }
 
 bool BlockMappingManager::UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
-                     int64_t block_version) {
+                     int64_t block_version, bool* need_sync_meta, std::string* file_name) {
     int32_t bucket_offset = GetBucketOffset(block_id);
-    return block_mapping_[bucket_offset]->UpdateBlockInfo(block_id, server_id, block_size, block_version);
+    return block_mapping_[bucket_offset]->UpdateBlockInfo(block_id, server_id,
+                                                          block_size, block_version,
+                                                          need_sync_meta, file_name);
 }
 
 void BlockMappingManager::RemoveBlocksForFile(const FileInfo& file_info) {

--- a/src/nameserver/block_mapping_manager.h
+++ b/src/nameserver/block_mapping_manager.h
@@ -21,7 +21,8 @@ public :
     bool ChangeReplicaNum(int64_t block_id, int32_t replica_num);
     void AddNewBlock(int64_t block_id, int32_t replica,
                      int64_t version, int64_t block_size,
-                     const std::vector<int32_t>* init_replicas);
+                     const std::vector<int32_t>* init_replicas,
+                     const std::string& path);
     bool UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
                          int64_t block_version);
     void RemoveBlocksForFile(const FileInfo& file_info);

--- a/src/nameserver/block_mapping_manager.h
+++ b/src/nameserver/block_mapping_manager.h
@@ -22,9 +22,9 @@ public :
     void AddNewBlock(int64_t block_id, int32_t replica,
                      int64_t version, int64_t block_size,
                      const std::vector<int32_t>* init_replicas,
-                     const std::string& path);
+                     const std::string& path, int64_t entry_id);
     bool UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
-                         int64_t block_version, bool* need_sync_meta, std::string* file_name);
+                         int64_t block_version, bool* need_sync_meta);
     void RemoveBlocksForFile(const FileInfo& file_info);
     void RemoveBlock(int64_t block_id);
     void DealWithDeadNode(int32_t cs_id, const std::set<int64_t>& blocks);

--- a/src/nameserver/block_mapping_manager.h
+++ b/src/nameserver/block_mapping_manager.h
@@ -24,7 +24,7 @@ public :
                      const std::vector<int32_t>* init_replicas,
                      const std::string& path);
     bool UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
-                         int64_t block_version);
+                         int64_t block_version, bool* need_sync_meta, std::string* file_name);
     void RemoveBlocksForFile(const FileInfo& file_info);
     void RemoveBlock(int64_t block_id);
     void DealWithDeadNode(int32_t cs_id, const std::set<int64_t>& blocks);

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -423,6 +423,7 @@ void NameServerImpl::AddBlock(::google::protobuf::RpcController* controller,
             path.c_str(), new_block_id, replica_num, request->client_address().c_str());
         file_info.add_blocks(new_block_id);
         file_info.set_version(-1);
+        file_info.set_name(path);
         ///TODO: Lost update? Get&Update not atomic.
         for (int i = 0; i < replica_num; i++) {
             file_info.add_cs_addrs(chunkserver_manager_->GetChunkServerAddr(chains[i].first));
@@ -443,7 +444,7 @@ void NameServerImpl::AddBlock(::google::protobuf::RpcController* controller,
             // update cs -> block
             chunkserver_manager_->AddBlock(cs_id, new_block_id);
         }
-        block_mapping_manager_->AddNewBlock(new_block_id, replica_num, -1, 0, &replicas);
+        block_mapping_manager_->AddNewBlock(new_block_id, replica_num, -1, 0, &replicas, path);
         block->set_block_id(new_block_id);
         response->set_status(kOK);
         LogRemote(log, boost::bind(&NameServerImpl::SyncLogCallback, this,
@@ -776,7 +777,7 @@ void NameServerImpl::RebuildBlockMapCallback(const FileInfo& file_info) {
         int64_t block_id = file_info.blocks(i);
         int64_t version = file_info.version();
         block_mapping_manager_->AddNewBlock(block_id, file_info.replicas(),
-                                    version, file_info.size(), NULL);
+                                    version, file_info.size(), NULL, file_info.name());
     }
 }
 

--- a/src/nameserver/nameserver_impl.h
+++ b/src/nameserver/nameserver_impl.h
@@ -132,7 +132,7 @@ private:
                     const ::google::protobuf::Message* request,
                     ::google::protobuf::Message* response,
                     ::google::protobuf::Closure* done);
-    void UpdateFileMeta(std::string file_name, int64_t block_size, int64_t block_version);
+    void UpdateFileMeta(int64_t block_id);
 private:
     /// Global thread pool
     ThreadPool* work_thread_pool_;

--- a/src/nameserver/nameserver_impl.h
+++ b/src/nameserver/nameserver_impl.h
@@ -132,6 +132,7 @@ private:
                     const ::google::protobuf::Message* request,
                     ::google::protobuf::Message* response,
                     ::google::protobuf::Closure* done);
+    void UpdateFileMeta(std::string file_name, int64_t block_size, int64_t block_version);
 private:
     /// Global thread pool
     ThreadPool* work_thread_pool_;

--- a/src/nameserver/namespace.cc
+++ b/src/nameserver/namespace.cc
@@ -177,8 +177,10 @@ bool NameSpace::UpdateFileInfo(const FileInfo& file_info, NameServerLog* log) {
     file_info_for_ldb.CopyFrom(file_info);
     file_info_for_ldb.clear_cs_addrs();
 
+    size_t pos = file_info_for_ldb.name().find_last_of("/");
+    std::string name = file_info_for_ldb.name().substr(pos + 1);
     std::string file_key;
-    EncodingStoreKey(file_info_for_ldb.parent_entry_id(), file_info_for_ldb.name(), &file_key);
+    EncodingStoreKey(file_info_for_ldb.parent_entry_id(), name, &file_key);
     std::string infobuf_for_ldb, infobuf_for_sync;
     file_info_for_ldb.SerializeToString(&infobuf_for_ldb);
     file_info.SerializeToString(&infobuf_for_sync);

--- a/src/nameserver/namespace.h
+++ b/src/nameserver/namespace.h
@@ -48,6 +48,8 @@ public:
     bool GetFileInfo(const std::string& path, FileInfo* file_info);
     /// Update file
     bool UpdateFileInfo(const FileInfo& file_info, NameServerLog* log = NULL);
+    bool UpdateFileInfo(int64_t parent_entry_id, const std::string& file_name,
+                        int64_t block_version, int64_t block_size, NameServerLog* log = NULL);
     /// Delete file
     bool DeleteFileInfo(const std::string file_key, NameServerLog* log = NULL);
     /// Namespace version

--- a/src/sdk/file_impl.cc
+++ b/src/sdk/file_impl.cc
@@ -493,7 +493,7 @@ void FileImpl::BackgroundWrite() {
             const int max_retry_times = 5;
             ChunkServer_Stub* stub = chunkservers_[cs_addr];
             boost::function<void (const WriteBlockRequest*, WriteBlockResponse*, bool, int)> callback
-                = boost::bind(&FileImpl::WriteChunkCallback, this, _1, _2, _3, _4,
+                = boost::bind(&FileImpl::WriteBlockCallback, this, _1, _2, _3, _4,
                         max_retry_times, buffer, cs_addr);
 
             LOG(DEBUG, "BackgroundWrite start [bid:%ld, seq:%d, offset:%ld, len:%d]\n",
@@ -522,7 +522,7 @@ void FileImpl::DelayWriteChunk(WriteBuffer* buffer,
                                   int retry_times, std::string cs_addr) {
     WriteBlockResponse* response = new WriteBlockResponse;
     boost::function<void (const WriteBlockRequest*, WriteBlockResponse*, bool, int)> callback
-        = boost::bind(&FileImpl::WriteChunkCallback, this, _1, _2, _3, _4,
+        = boost::bind(&FileImpl::WriteBlockCallback, this, _1, _2, _3, _4,
                       retry_times, buffer, cs_addr);
     common::atomic_inc(&back_writing_);
     ChunkServer_Stub* stub = chunkservers_[cs_addr];
@@ -535,7 +535,7 @@ void FileImpl::DelayWriteChunk(WriteBuffer* buffer,
     }
 }
 
-void FileImpl::WriteChunkCallback(const WriteBlockRequest* request,
+void FileImpl::WriteBlockCallback(const WriteBlockRequest* request,
                                      WriteBlockResponse* response,
                                      bool failed, int error,
                                      int retry_times,
@@ -606,7 +606,7 @@ void FileImpl::WriteChunkCallback(const WriteBlockRequest* request,
     delete response;
 
     {
-        MutexLock lock(&mu_, "WriteChunkCallback", 1000);
+        MutexLock lock(&mu_, "WriteBlockCallback", 1000);
         if (write_queue_.empty() || bg_error_) {
             common::atomic_dec(&back_writing_);    // for AsyncRequest
             if (back_writing_ == 0) {

--- a/src/sdk/file_impl.h
+++ b/src/sdk/file_impl.h
@@ -82,7 +82,7 @@ public:
     void BackgroundWrite();
     /// Callback for sliding window
     void OnWriteCommit(int32_t, int32_t);
-    void WriteChunkCallback(const WriteBlockRequest* request,
+    void WriteBlockCallback(const WriteBlockRequest* request,
                             WriteBlockResponse* response,
                             bool failed, int error,
                             int retry_times,


### PR DESCRIPTION
还有一点没写完，以及没有仔细测试，你们先吐槽一下，这个应该会使nameserver更占内存。。

block meta落盘时，需要知道落到namespace中哪个文件里，然而这个反向的是查不到的。只好在AddBlock时先记一下这个block对应的文件名。
另外一种做法可能需要后台定时扫目录树？
