### PR TITLE
Sdk retry when too much unfinished write

### DIFF
--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -452,7 +452,11 @@ void ChunkServerImpl::WriteNextCallback(const WriteBlockRequest* next_request,
                      "status= %s, error= %d\n",
             next_server.c_str(), block_id, packet_seq, offset, databuf.size(),
             StatusCode_Name(next_response->status()).c_str(), error);
-        response->set_status(kWriteError);
+        if (failed) {
+            response->set_status(kNetworkUnavailable);
+        } else {
+            response->set_status(next_response->status());
+        }
         delete next_response;
         g_unfinished_bytes.Sub(databuf.size());
         done->Run();

--- a/src/sdk/file_impl.cc
+++ b/src/sdk/file_impl.cc
@@ -547,7 +547,8 @@ void FileImpl::WriteBlockCallback(const WriteBlockRequest* request,
                                      std::string cs_addr) {
     if (failed || response->status() != kOK) {
         if (sofa::pbrpc::RPC_ERROR_SEND_BUFFER_FULL != error
-                && response->status() != kCsTooMuchPendingBuffer) {
+                && response->status() != kCsTooMuchPendingBuffer
+                && response->status() != kCsTooMuchUnfinishedWrite) {
             if (retry_times < 5) {
                 LOG(INFO, "BackgroundWrite failed %s"
                     " #%ld seq:%d, offset:%ld, len:%d"


### PR DESCRIPTION
先来个并不是总给sdk返回kWriteError的