### PR TITLE
Use weak_ptr in callback #480

### DIFF
--- a/src/sdk/file_impl.cc
+++ b/src/sdk/file_impl.cc
@@ -323,7 +323,7 @@ int32_t FileImpl::AddBlock() {
         const std::string& addr = block_for_write_->chains(i).address();
         rpc_client_->GetStub(addr, &chunkservers_[addr]);
         write_windows_[addr] = new common::SlidingWindow<int>(100,
-                               boost::bind(&FileImpl::OnWriteCommit, this, _1, _2));
+                               boost::bind(&FileImpl::OnWriteCommit, _1, _2));
         cs_errors_[addr] = false;
         WriteBlockRequest create_request;
         int64_t seq = common::timer::get_micros();

--- a/src/sdk/file_impl.cc
+++ b/src/sdk/file_impl.cc
@@ -542,6 +542,8 @@ void FileImpl::DelayWriteChunk(boost::weak_ptr<FileImpl> wk_fp,
     boost::shared_ptr<FileImpl> fp(wk_fp.lock());
     if (!fp) {
         LOG(DEBUG, "FileImpl has been destroied, ignore delay write");
+        buffer->DecRef();
+        delete request;
         return;
     }
     fp->DelayWriteChunkInternal(buffer, request, retry_times, cs_addr);
@@ -577,6 +579,9 @@ void FileImpl::WriteBlockCallback(boost::weak_ptr<FileImpl> wk_fp,
     boost::shared_ptr<FileImpl> fp(wk_fp.lock());
     if (!fp) {
         LOG(DEBUG, "FileImpl has been destroied, ignore this callback");
+        buffer->DecRef();
+        delete request;
+        delete response;
         return;
     }
     fp->WriteBlockCallbackInternal(request, response, failed, error, retry_times, buffer, cs_addr);

--- a/src/sdk/file_impl.cc
+++ b/src/sdk/file_impl.cc
@@ -323,8 +323,7 @@ int32_t FileImpl::AddBlock() {
         const std::string& addr = block_for_write_->chains(i).address();
         rpc_client_->GetStub(addr, &chunkservers_[addr]);
         write_windows_[addr] = new common::SlidingWindow<int>(100,
-                               boost::bind(&FileImpl::OnWriteCommit,
-                                   boost::weak_ptr<FileImpl>(shared_from_this()), _1, _2));
+                               boost::bind(&FileImpl::OnWriteCommit, this, _1, _2));
         cs_errors_[addr] = false;
         WriteBlockRequest create_request;
         int64_t seq = common::timer::get_micros();
@@ -676,16 +675,7 @@ void FileImpl::WriteBlockCallbackInternal(const WriteBlockRequest* request,
     thread_pool_->AddTask(task);
 }
 
-void FileImpl::OnWriteCommit(boost::weak_ptr<FileImpl> wk_fp, int32_t offset, int32_t item) {
-    boost::shared_ptr<FileImpl> fp(wk_fp.lock());
-    if (!fp) {
-        LOG(DEBUG, "FileImpl has been destroied");
-        return;
-    }
-    fp->OnWriteCommitInternal(offset, item);
-}
-
-void FileImpl::OnWriteCommitInternal(int32_t, int32_t) {
+void FileImpl::OnWriteCommit(int32_t, int) {
 }
 
 int32_t FileImpl::Flush() {

--- a/src/sdk/file_impl.cc
+++ b/src/sdk/file_impl.cc
@@ -323,7 +323,8 @@ int32_t FileImpl::AddBlock() {
         const std::string& addr = block_for_write_->chains(i).address();
         rpc_client_->GetStub(addr, &chunkservers_[addr]);
         write_windows_[addr] = new common::SlidingWindow<int>(100,
-                               boost::bind(&FileImpl::OnWriteCommit, this, _1, _2));
+                               boost::bind(&FileImpl::OnWriteCommit,
+                                   boost::weak_ptr<FileImpl>(shared_from_this()), _1, _2));
         cs_errors_[addr] = false;
         WriteBlockRequest create_request;
         int64_t seq = common::timer::get_micros();
@@ -675,7 +676,16 @@ void FileImpl::WriteBlockCallbackInternal(const WriteBlockRequest* request,
     thread_pool_->AddTask(task);
 }
 
-void FileImpl::OnWriteCommit(int32_t, int) {
+void FileImpl::OnWriteCommit(boost::weak_ptr<FileImpl> wk_fp, int32_t offset, int32_t item) {
+    boost::shared_ptr<FileImpl> fp(wk_fp.lock());
+    if (!fp) {
+        LOG(DEBUG, "FileImpl has been destroied");
+        return;
+    }
+    fp->OnWriteCommitInternal(offset, item);
+}
+
+void FileImpl::OnWriteCommitInternal(int32_t, int32_t) {
 }
 
 int32_t FileImpl::Flush() {

--- a/src/sdk/file_impl.h
+++ b/src/sdk/file_impl.h
@@ -83,7 +83,7 @@ public:
     /// Send local buffer to chunkserver
     static void BackgroundWrite(boost::weak_ptr<FileImpl> wk_fp);
     /// Callback for sliding window
-    static void OnWriteCommit(boost::weak_ptr<FileImpl> wk_fp, int32_t, int32_t);
+    void OnWriteCommit(int32_t, int32_t);
     static void WriteBlockCallback(boost::weak_ptr<FileImpl> wk_fp,
                             const WriteBlockRequest* request,
                             WriteBlockResponse* response,
@@ -117,7 +117,6 @@ private:
                             std::string cs_addr);
     void DelayWriteChunkInternal(WriteBuffer* buffer, const WriteBlockRequest* request,
                                 int retry_times, std::string cs_addr);
-    void OnWriteCommitInternal(int32_t, int32_t);
 private:
     FSImpl* fs_;                        ///< 文件系统
     RpcClient* rpc_client_;             ///< RpcClient

--- a/src/sdk/file_impl.h
+++ b/src/sdk/file_impl.h
@@ -83,7 +83,7 @@ public:
     /// Send local buffer to chunkserver
     static void BackgroundWrite(boost::weak_ptr<FileImpl> wk_fp);
     /// Callback for sliding window
-    void OnWriteCommit(int32_t, int32_t);
+    static void OnWriteCommit(boost::weak_ptr<FileImpl> wk_fp, int32_t, int32_t);
     static void WriteBlockCallback(boost::weak_ptr<FileImpl> wk_fp,
                             const WriteBlockRequest* request,
                             WriteBlockResponse* response,
@@ -117,6 +117,7 @@ private:
                             std::string cs_addr);
     void DelayWriteChunkInternal(WriteBuffer* buffer, const WriteBlockRequest* request,
                                 int retry_times, std::string cs_addr);
+    void OnWriteCommitInternal(int32_t, int32_t);
 private:
     FSImpl* fs_;                        ///< 文件系统
     RpcClient* rpc_client_;             ///< RpcClient

--- a/src/sdk/file_impl.h
+++ b/src/sdk/file_impl.h
@@ -83,7 +83,7 @@ public:
     /// Send local buffer to chunkserver
     static void BackgroundWrite(boost::weak_ptr<FileImpl> wk_fp);
     /// Callback for sliding window
-    void OnWriteCommit(int32_t, int32_t);
+    static void OnWriteCommit(int32_t, int32_t);
     static void WriteBlockCallback(boost::weak_ptr<FileImpl> wk_fp,
                             const WriteBlockRequest* request,
                             WriteBlockResponse* response,

--- a/src/sdk/file_impl.h
+++ b/src/sdk/file_impl.h
@@ -15,6 +15,8 @@
 #include <common/timer.h>
 #include <common/sliding_window.h>
 #include <common/thread_pool.h>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/weak_ptr.hpp>
 
 #include "proto/nameserver.pb.h"
 #include "proto/chunkserver.pb.h"
@@ -65,7 +67,7 @@ struct LocatedBlocks {
     }
 };
 
-class FileImpl : public File {
+class FileImpl : public File, public boost::enable_shared_from_this<FileImpl> {
 public:
     FileImpl(FSImpl* fs, RpcClient* rpc_client, const std::string& name,
              int32_t flags, const WriteOptions& options);
@@ -79,18 +81,20 @@ public:
     /// Add buffer to  async write list
     void StartWrite();
     /// Send local buffer to chunkserver
-    void BackgroundWrite();
+    static void BackgroundWrite(boost::weak_ptr<FileImpl> wk_fp);
     /// Callback for sliding window
     void OnWriteCommit(int32_t, int32_t);
-    void WriteBlockCallback(const WriteBlockRequest* request,
+    static void WriteBlockCallback(boost::weak_ptr<FileImpl> wk_fp,
+                            const WriteBlockRequest* request,
                             WriteBlockResponse* response,
                             bool failed, int error,
                             int retry_times,
                             WriteBuffer* buffer,
                             std::string cs_addr);
     /// When rpc buffer full deley send write reqeust
-    void DelayWriteChunk(WriteBuffer* buffer, const WriteBlockRequest* request,
-                         int retry_times, std::string cs_addr);
+    static void DelayWriteChunk(boost::weak_ptr<FileImpl> wk_fp,
+                                WriteBuffer* buffer, const WriteBlockRequest* request,
+                                int retry_times, std::string cs_addr);
     int32_t Flush();
     int32_t Sync();
     int32_t Close();
@@ -104,6 +108,15 @@ public:
 private:
     int32_t AddBlock();
     bool CheckWriteWindows();
+    void BackgroundWriteInternal();
+    void WriteBlockCallbackInternal(const WriteBlockRequest* request,
+                            WriteBlockResponse* response,
+                            bool failed, int error,
+                            int retry_times,
+                            WriteBuffer* buffer,
+                            std::string cs_addr);
+    void DelayWriteChunkInternal(WriteBuffer* buffer, const WriteBlockRequest* request,
+                                int retry_times, std::string cs_addr);
 private:
     FSImpl* fs_;                        ///< 文件系统
     RpcClient* rpc_client_;             ///< RpcClient


### PR DESCRIPTION
#480 
治活扇出写第二步：将所有bind中传this指针的地方改为传weak_ptr，实际执行时尝试将weak_ptr提升为shared_ptr，若失败，则跳过回调执行流程
FileImpl中的OnWriteCommit是什么鬼，除了那里，其它地方的bind都改成了weak_ptr