### PR TITLE
Fix build_version.sh

### DIFF
--- a/build_version.sh
+++ b/build_version.sh
@@ -16,9 +16,9 @@ gen_info_template_header ()
 
 gen_info_template_foot ()
 {
-    echo "extern const char kBuildTime[] = \"$BUILD_DATE_TIME\";"
-    echo "extern const char kBuilderName[] = \"$USER\";"
-    echo "extern const char kHostName[] = \"$BUILD_HOSTNAME\";"
+    echo "const char kBuildTime[] = \"$BUILD_DATE_TIME\";"
+    echo "const char kBuilderName[] = \"$USER\";"
+    echo "const char kHostName[] = \"$BUILD_HOSTNAME\";"
 }
 
 gen_info_print_template ()


### PR DESCRIPTION
no need to use `extern`