### PR TITLE
support different compiler, when compiler version less than 4.8.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -188,6 +188,12 @@ echo "TCMALLOC_PATH=./thirdparty" >> depends.mk
 # build tera
 ########################################
 
+# support compiler version less than 4.8.2
+if [[ "4.8.2" > `/usr/bin/g++ -dumpversion` ]]
+then
+    sed -i 's/-std=c++11/-std=c++0x/g' Makefile
+fi
+
 make clean
 make -j4
 


### PR DESCRIPTION
默认是使用C++ 11编译的，即-std=c++11，但是这样编译需要的编译器版本是需要大于等于4.8.2的。

我本人电脑的编译器版本是 g++ (GCC) 4.4.7 20120313 (Red Hat 4.4.7-4) ，这种编译的话，需要将编译参数改为 -std=c++0x，即可以编译成功。

为了支持不同的编译器版本，所以修改了build.sh 文件，将小于4.8.2版本的编译参数替换即可。