### PR TITLE
Fix report check missing the last blocks

### DIFF
--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/vfs.h>
+#include <climits>
 #include <functional>
 
 #include <gflags/gflags.h>
@@ -261,7 +262,7 @@ void ChunkServerImpl::SendBlockReport() {
 
     std::vector<BlockMeta> blocks;
     int32_t num = is_first_round_ ? 10000 : params_.report_size();
-    int32_t end = block_manager_->ListBlocks(&blocks, last_report_blockid_ + 1, num);
+    int64_t end = block_manager_->ListBlocks(&blocks, last_report_blockid_ + 1, num);
     // last id + 1 <= first found report start <= end -> first round ends
     if (is_first_round_ &&
         (last_report_blockid_ + 1) <= first_round_report_start_ &&
@@ -284,6 +285,7 @@ void ChunkServerImpl::SendBlockReport() {
 
     if (blocks_num < num) {
         last_report_blockid_ = -1;
+        end = LLONG_MAX;
     } else {
         last_report_blockid_ = end;
     }

--- a/src/nameserver/chunkserver_manager.h
+++ b/src/nameserver/chunkserver_manager.h
@@ -25,7 +25,8 @@ public:
     void Insert(int64_t block_id);
     void Remove(int64_t block_id);
     void CleanUp(std::set<int64_t>* blocks);
-    int64_t CheckLost(int64_t report_id, std::set<int64_t>& blocks,
+    void MoveNew();
+    int64_t CheckLost(int64_t report_id, const std::set<int64_t>& blocks,
                       int64_t start, int64_t end, std::vector<int64_t>* lost);
 private:
     Mutex block_mu_;
@@ -69,8 +70,8 @@ public:
                  int64_t* r_speed, int64_t* recover_speed);
     StatusCode ShutdownChunkServer(const::google::protobuf::RepeatedPtrField<std::string>& chunkserver_address);
     bool GetShutdownChunkServerStat();
-    int64_t AddBlockWithCheck(int32_t id, std::set<int64_t>& blocks, int64_t start, int64_t end,
-                  std::vector<int64_t>* lost, int64_t report_id);
+    int64_t AddBlockWithCheck(int32_t id, const std::set<int64_t>& blocks, int64_t start, int64_t end,
+                              std::vector<int64_t>* lost, int64_t report_id);
     void SetParam(const Params& p);
 private:
     double GetChunkServerLoad(ChunkServerInfo* cs);


### PR DESCRIPTION
(#507) When reporting the last few blocks, CS set the 'end' to LLONG_MAX
instead of the lasgest block_id. So the NS can find out if CS has lost
the last few blocks.