### PR TITLE
Add RebuildBlock in BlockMapping

### DIFF
--- a/src/nameserver/block_mapping.cc
+++ b/src/nameserver/block_mapping.cc
@@ -83,32 +83,16 @@ bool BlockMapping::ChangeReplicaNum(int64_t block_id, int32_t replica_num) {
     return true;
 }
 
-void BlockMapping::AddNewBlock(int64_t block_id, int32_t replica,
-                               int64_t version, int64_t size,
-                               const std::vector<int32_t>* init_replicas) {
+void BlockMapping::AddBlock(int64_t block_id, int32_t replica, int64_t version,
+                            int64_t size, const std::vector<int32_t>& init_replicas) {
     NSBlock* nsblock = NULL;
     nsblock = new NSBlock(block_id, replica, version, size);
-    if (init_replicas) {
-        if (nsblock->recover_stat == kNotInRecover) {
-            nsblock->replica.insert(init_replicas->begin(), init_replicas->end());
-        } else {
-            nsblock->incomplete_replica.insert(init_replicas->begin(), init_replicas->end());
-        }
-        LOG(DEBUG, "Init block info: #%ld ", block_id);
+    if (nsblock->recover_stat == kNotInRecover) {
+        nsblock->replica.insert(init_replicas.begin(), init_replicas.end());
     } else {
-        if (size) {
-            nsblock->recover_stat = kLost;
-            lost_blocks_.insert(block_id);
-        } else {
-            nsblock->recover_stat = kBlockWriting;
-        }
-
-        if (version < 0) {
-            LOG(INFO, "Rebuild writing block #%ld V%ld %ld", block_id, version, size);
-        } else {
-            LOG(DEBUG, "Rebuild block #%ld V%ld %ld", block_id, version, size);
-        }
+        nsblock->incomplete_replica.insert(init_replicas.begin(), init_replicas.end());
     }
+    LOG(DEBUG, "Init block info: #%ld ", block_id);
     g_blocks_num.Inc();
     MutexLock lock(&mu_);
     common::timer::TimeChecker insert_time;
@@ -116,6 +100,32 @@ void BlockMapping::AddNewBlock(int64_t block_id, int32_t replica,
         block_map_.insert(std::make_pair(block_id, nsblock));
     assert(ret.second == true);
     insert_time.Check(10 * 1000, "[AddNewBlock] InsertToBlockMapping");
+}
+
+void BlockMapping::RebuildBlock(int64_t block_id, int32_t replica,
+                                int64_t version, int64_t size) {
+    NSBlock* nsblock = NULL;
+    nsblock = new NSBlock(block_id, replica, version, size);
+    if (size) {
+        nsblock->recover_stat = kLost;
+        lost_blocks_.insert(block_id);
+    } else {
+        nsblock->recover_stat = kBlockWriting;
+    }
+
+    if (version < 0) {
+        LOG(INFO, "Rebuild writing block #%ld V%ld %ld", block_id, version, size);
+    } else {
+        LOG(DEBUG, "Rebuild block #%ld V%ld %ld", block_id, version, size);
+    }
+
+    g_blocks_num.Inc();
+    MutexLock lock(&mu_);
+    common::timer::TimeChecker insert_time;
+    std::pair<NSBlockMap::iterator, bool> ret =
+        block_map_.insert(std::make_pair(block_id, nsblock));
+    assert(ret.second == true);
+    insert_time.Check(10 * 1000, "[RebuildBlock] InsertToBlockMapping");
 }
 
 bool BlockMapping::UpdateWritingBlock(NSBlock* nsblock,

--- a/src/nameserver/block_mapping.h
+++ b/src/nameserver/block_mapping.h
@@ -61,9 +61,10 @@ public:
     bool GetBlock(int64_t block_id, NSBlock* block);
     bool GetLocatedBlock(int64_t id, std::vector<int32_t>* replica, int64_t* block_size, RecoverStat* status);
     bool ChangeReplicaNum(int64_t block_id, int32_t replica_num);
-    void AddNewBlock(int64_t block_id, int32_t replica,
-                     int64_t version, int64_t block_size,
-                     const std::vector<int32_t>* init_replicas);
+    void AddBlock(int64_t block_id, int32_t replica, int64_t version,
+                  int64_t size, const std::vector<int32_t>& init_replicas);
+    void RebuildBlock(int64_t block_id, int32_t replica,
+                      int64_t version, int64_t size);
     bool UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
                          int64_t block_version);
     void RemoveBlocksForFile(const FileInfo& file_info, std::map<int64_t, std::set<int32_t> >* blocks);

--- a/src/nameserver/block_mapping_manager.cc
+++ b/src/nameserver/block_mapping_manager.cc
@@ -50,11 +50,18 @@ bool BlockMappingManager::ChangeReplicaNum(int64_t block_id, int32_t replica_num
     return block_mapping_[bucket_offset]->ChangeReplicaNum(block_id, replica_num);
 }
 
-void BlockMappingManager::AddNewBlock(int64_t block_id, int32_t replica,
-                 int64_t version, int64_t block_size,
-                 const std::vector<int32_t>* init_replicas) {
+void BlockMappingManager::AddBlock(int64_t block_id, int32_t replica,
+                                   int64_t version, int64_t size,
+                                   const std::vector<int32_t>& init_replicas) {
     int32_t bucket_offset = GetBucketOffset(block_id);
-    block_mapping_[bucket_offset]->AddNewBlock(block_id, replica, version, block_size, init_replicas);
+    block_mapping_[bucket_offset]->AddBlock(block_id, replica, version,
+                                               size, init_replicas);
+}
+
+void BlockMappingManager::RebuildBlock(int64_t block_id, int32_t replica,
+                                       int64_t version, int64_t size) {
+    int32_t bucket_offset = GetBucketOffset(block_id);
+    block_mapping_[bucket_offset]->RebuildBlock(block_id, replica, version, size);
 }
 
 bool BlockMappingManager::UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,

--- a/src/nameserver/block_mapping_manager.h
+++ b/src/nameserver/block_mapping_manager.h
@@ -20,9 +20,10 @@ public :
     bool GetBlock(int64_t block_id, NSBlock* block);
     bool GetLocatedBlock(int64_t id, std::vector<int32_t>* replica, int64_t* block_size, RecoverStat* stauts);
     bool ChangeReplicaNum(int64_t block_id, int32_t replica_num);
-    void AddNewBlock(int64_t block_id, int32_t replica,
-                     int64_t version, int64_t block_size,
-                     const std::vector<int32_t>* init_replicas);
+    void AddBlock(int64_t block_id, int32_t replica, int64_t version,
+                  int64_t size, const std::vector<int32_t>& init_replicas);
+    void RebuildBlock(int64_t block_id, int32_t replica,
+                     int64_t version, int64_t size);
     bool UpdateBlockInfo(int64_t block_id, int32_t server_id, int64_t block_size,
                          int64_t block_version);
     void RemoveBlocksForFile(const FileInfo& file_info, std::map<int64_t, std::set<int32_t> >* blocks);

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -496,7 +496,7 @@ void NameServerImpl::AddBlock(::google::protobuf::RpcController* controller,
             chunkserver_manager_->AddBlock(cs_id, new_block_id);
             add_block_timer.Check(50 * 1000, "AddBlock");
         }
-        block_mapping_manager_->AddNewBlock(new_block_id, replica_num, -1, 0, &replicas);
+        block_mapping_manager_->AddBlock(new_block_id, replica_num, -1, 0, replicas);
         add_block_timer.Check(50 * 1000, "AddNewBlock");
         block->set_block_id(new_block_id);
         response->set_status(kOK);
@@ -899,8 +899,8 @@ void NameServerImpl::RebuildBlockMapCallback(const FileInfo& file_info) {
     for (int i = 0; i < file_info.blocks_size(); i++) {
         int64_t block_id = file_info.blocks(i);
         int64_t version = file_info.version();
-        block_mapping_manager_->AddNewBlock(block_id, file_info.replicas(),
-                                    version, file_info.size(), NULL);
+        block_mapping_manager_->RebuildBlock(block_id, file_info.replicas(),
+                                            version, file_info.size());
     }
 }
 


### PR DESCRIPTION
(#617) 'AddNewBlock' is used both in adding new blocks and rebuild
exist blocks. Use separate functions to deal with different
situations.