### PR TITLE
make gcc work well when using fuse

### DIFF
--- a/fuse/bfs_mount.cc
+++ b/fuse/bfs_mount.cc
@@ -252,9 +252,9 @@ int bfs_statfs(const char* path, struct statvfs*) {
 int bfs_flush(const char* path, struct fuse_file_info* finfo) {
     baidu::bfs::File* file = get_bfs_file(finfo);
     fprintf(stderr, BFS"flush(%s, %p)\n", path, file);
-    int32_t ret = file->Sync();
+    int32_t ret = file->Flush();
     if (ret != OK) {
-        fprintf(stderr, BFS"fsync(%s, %p) fail, error code %s\n",
+        fprintf(stderr, BFS"flush(%s, %p) fail, error code %s\n",
                 path, file, baidu::bfs::StrError(ret));
         return EIO;
     }


### PR DESCRIPTION
bfs打开文件都是只读打开，gcc flush文件时，会返回BAD_PARAMETER

flush实际只是把FILE*中的buffer刷到os，也不保证不丢数据，所以不需要调用Sync()接口

把之前的Sync接口改成了`FileImpl::Flush()`，该接口未实现，但是不影响正常使用

