### PR TITLE
Fix vim write error when using fuse

### DIFF
--- a/fuse/bfs_mount.cc
+++ b/fuse/bfs_mount.cc
@@ -200,7 +200,7 @@ int bfs_write(const char* path, const char* buf, size_t len, off_t offset, struc
             mfile->buf = new char[new_buf_len];
             mfile->buf_len = new_buf_len;
             int rlen = file->Pread(mfile->buf, mfile->offset, 0);
-            if (rlen < mfile->offset) {
+            if (rlen != 0 && rlen < mfile->offset) {
                 fprintf(stderr, BFS"Read(%ld) for randmon write(%s, %ld, %lu) fail", mfile->offset, path, offset, len);
                 delete[] mfile->buf;
                 mfile->buf = NULL;


### PR DESCRIPTION
文件随机写 第一次打开时 `rlen` 可能等于0 应该属于正常情况，之前的判断条件会导致vim不能正常写入swap文件