### PR TITLE
Update file_cache.h

### DIFF
--- a/src/chunkserver/file_cache.h
+++ b/src/chunkserver/file_cache.h
@@ -19,6 +19,9 @@ public:
     int64_t ReadFile(const std::string& file_path, char* buf, int64_t count, int64_t offset);
     void EraseFileCache(const std::string& file_path);
 private:
+    FileCache(const FileCache&) {}
+    const FileCache& operator=() {}
+private:
     common::Cache::Handle* FindFile(const std::string& file_path);
 private:
     common::Cache* cache_;

--- a/src/chunkserver/file_cache.h
+++ b/src/chunkserver/file_cache.h
@@ -20,7 +20,7 @@ public:
     void EraseFileCache(const std::string& file_path);
 private:
     FileCache(const FileCache&) {}
-    const FileCache& operator=() {}
+    void operator=() {}
 private:
     common::Cache::Handle* FindFile(const std::string& file_path);
 private:

--- a/src/chunkserver/file_cache.h
+++ b/src/chunkserver/file_cache.h
@@ -20,7 +20,7 @@ public:
     void EraseFileCache(const std::string& file_path);
 private:
     FileCache(const FileCache&) {}
-    void operator=() {}
+    void operator=(const FileCache&) {}
 private:
     common::Cache::Handle* FindFile(const std::string& file_path);
 private:


### PR DESCRIPTION
The class in the file, FileCache, has the member to pointer. And it is better to implement copy constructor and copy assignment by ourselves instead of the compiler.  Maybe it is better to make them private.