### PR TITLE
Gc something at destory "NameSlaveImpl" instance and format logs

### DIFF
--- a/src/nameserver/logdb.cc
+++ b/src/nameserver/logdb.cc
@@ -22,6 +22,7 @@ LogDB::~LogDB() {
     if (thread_pool_) {
         thread_pool_->Stop(true);
     }
+    delete thread_pool_;
     if (write_log_) fclose(write_log_);
     for (FileCache::iterator it = read_log_.begin(); it != read_log_.end(); ++it) {
         fclose((it->second).first);

--- a/src/nameserver/master_slave.h
+++ b/src/nameserver/master_slave.h
@@ -25,7 +25,7 @@ class RpcClient;
 class MasterSlaveImpl : public Sync, public master_slave::MasterSlave {
 public:
     MasterSlaveImpl();
-    virtual ~MasterSlaveImpl() {};
+    virtual ~MasterSlaveImpl();
     virtual void Init(std::function<void (const std::string& log)> callback);
     virtual bool IsLeader(std::string* leader_addr = NULL);
     virtual bool Log(const std::string& entry, int timeout_ms = 10000);

--- a/src/nameserver/namespace.cc
+++ b/src/nameserver/namespace.cc
@@ -38,6 +38,7 @@ NameSpace::NameSpace(bool standalone): version_(0), last_entry_id_(1),
     options.block_cache = leveldb::NewLRUCache(FLAGS_namedb_cache_size * 1024L * 1024L);
     leveldb::Status s = leveldb::DB::Open(options, FLAGS_namedb_path, &db_);
     if (!s.ok()) {
+        delete db_;
         db_ = NULL;
         LOG(ERROR, "Open leveldb fail: %s", s.ToString().c_str());
         exit(EXIT_FAILURE);


### PR DESCRIPTION
1. int64_t 用 %d 打印不会报错，存在溢出风险
2. 个人理解NameSlaveImpl缺少必要的析构，和对堆上分配资源的回收