### PR TITLE
fixed: if wget download boost fail once,  fail all the time.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,7 @@ cd ${DEPS_SOURCE}
 # boost
 if [ ! -f "${FLAG_DIR}/boost_1_57_0" ] \
     || [ ! -d "${DEPS_PREFIX}/boost_1_57_0/boost" ]; then
+    rm boost_1_57_0.tar.gz 
     wget https://raw.githubusercontent.com/lylei9/boost_1_57_0/master/boost_1_57_0.tar.gz
     tar zxf boost_1_57_0.tar.gz
     rm -rf ${DEPS_PREFIX}/boost_1_57_0


### PR DESCRIPTION
if wget fail by network error,  it would leave a broken file, and the build.sh fail.
when run the build.sh again,  wget will rename the new download file with 
"boost_1_57_0.tar.gz.1", "boost_1_57_0.tar.gz.2","boost_1_57_0.tar.gz.3"...
  
and the tar only target the oldest file(the broken one).  and tar will fail with "stdin: unexpected end of file".
so
rm boost_1_57_0.tar.gz 
before wget fixed it.