### PR TITLE
Minor bug fix for shell scripts in sandbox directory

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014, Bluebore
+Copyright (c) 2015, Baidu.inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Baidu File System (BFS) is a distributed file system designed to support rea
 2. High throughput
 	* High performance data engine to maximize IO utils.
 3. Low latency
-	* Global load balance and slow node detection.
+	* Global load balance and straggling node detection.
 4. Linear scalability
 	* Support multi data center deployment and up to 10,000 data nodes.
 
@@ -31,7 +31,7 @@ The Baidu File System (BFS) is a distributed file system designed to support rea
 2. Find something you are interested in and start working on it.
 3. Test your code by simply running `make test` and `make check`.
 4. Make a pull request.
-5. Once your code has passed the code-review and merged, it will be run on thousands of servers :)
+5. Once your code has passed the code-review and merged, it will run on thousands of servers :)
 
 
 ## Contact us

--- a/sandbox/clear.sh
+++ b/sandbox/clear.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-killall -9 nameserver
-killall -9 chunkserver
-killall -9 bfs_client
+killall -9 nameserver  > /dev/null 2>&1
+killall -9 chunkserver > /dev/null 2>&1
+killall -9 bfs_client  > /dev/null 2>&1
 
 rm -rf nameserver* chunkserver*
 rm -rf master* slave*

--- a/sandbox/deploy.sh
+++ b/sandbox/deploy.sh
@@ -10,8 +10,16 @@ if [ "$1"x = "x" ]; then
     ns_num=1;
 elif [ "$1x" == "raftx" ]; then
     ns_num=3
-elif [ "$1x" == "master_slave" ]; then
+elif [ "$1" == "master_slave" ]; then
     ns_num=2
+elif [ "$1" == "-h" ]; then
+    echo "Usage:"
+    echo "    $0 [mode = none | master_slave | raft | -h]"
+    echo "        none:         one nameserver, default mode."
+    echo "        master_slave: two nameservers, one is master and the other is slave."
+    echo "        raft:         three nameservers, master server is choosen by inbuilt raft protocol."
+    echo "        -h:           show this usage."
+    exit 0
 fi
 
 echo '--default_replica_num=3' >> bfs.flag

--- a/sandbox/small_test.sh
+++ b/sandbox/small_test.sh
@@ -21,6 +21,9 @@ fi
 
 
 sleep 5
+if [ "$1"x == "raft"x ]; then
+    sleep 30
+fi
 
 # Test sl
 ./bfs_client ls /
@@ -110,6 +113,9 @@ do
 done;
 
 sleep 10
+if [ "$1"x == "raft"x ]; then
+    sleep 30
+fi
 ./bfs_client get /bin/bfs_client ./binary
 rm -rf ./binary
 

--- a/sandbox/start_bfs.sh
+++ b/sandbox/start_bfs.sh
@@ -12,19 +12,22 @@ do
     cd nameserver$i;
     ./bin/nameserver --node_index=$i 1>nlog 2>&1 &
     echo $! > pid
-    cd -
+    echo "start nameserver$i with pid `cat pid`"
+    cd - > /dev/null
 done;
 
 if [ "$1"x == "master_slave"x ]; then
     cd nameserver0;
     ./bin/nameserver --master_slave_role=slave --node_index=0 1>nlog 2>&1 &
     echo $! > pid
-    cd -
+    echo "start slave nameserver0 with pid `cat pid`"
+    cd - > /dev/null
     sleep 1
     cd nameserver1;
     ./bin/nameserver --master_slave_role=master --node_index=1 1>nlog 2>&1 &
     echo $! > pid
-    cd -
+    echo "start master nameserver1 with pid `cat pid`"
+    cd - > /dev/null
 fi
 
 for i in `seq 0 3`;
@@ -32,5 +35,6 @@ do
     cd chunkserver$i;
     ./bin/chunkserver --chunkserver_port=802$i 1>clog1 2>&1 &
     echo $! > pid
-    cd -
+    echo "start chunkserver$i with pid `cat pid` at port 802$i"
+    cd - > /dev/null
 done


### PR DESCRIPTION
(#897)
1. `deploy.sh`:    extra x in `"$1"x == "master_slave"`. Also add `-h` option which is common in linux shell scripts.
2. `start_bfs.sh`: bfs can not work well with raft mode enabled with only sleeping 5 seconds, add 'sleep 30' when using raft mode.
3. `start_bfs.sh`: `cd -` print the working directory which is useless. Add the server starting message like `start nameserver0 with pid xxx`.
4. `clear.sh`:     redirect the error log message like `process not found` to `/dev/null`. It does no good but confuses the users.