### PR TITLE
add wget no-check-certificate in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ if [ ! -f "${FLAG_DIR}/boost_1_57_0" ] \
     if [ -e boost_1_57_0.tar.gz  ]; then
         rm boost_1_57_0.tar.gz 
     fi 
-    wget https://raw.githubusercontent.com/lylei9/boost_1_57_0/master/boost_1_57_0.tar.gz
+    wget --no-check-certificate https://raw.githubusercontent.com/lylei9/boost_1_57_0/master/boost_1_57_0.tar.gz
     tar zxf boost_1_57_0.tar.gz
     rm -rf ${DEPS_PREFIX}/boost_1_57_0
     mv boost_1_57_0 ${DEPS_PREFIX}/boost_1_57_0


### PR DESCRIPTION
If a machine use git for the first time, the command `sh build.sh` may throw an error as follows. So, it needs use --no-check-certificate in wget
```+ wget https://raw.githubusercontent.com/lylei9/boost_1_57_0/master/boost_1_57_0.tar.gz
--2017-08-09 15:49:06--  https://raw.githubusercontent.com/lylei9/boost_1_57_0/master/boost_1_57_0.tar.gz
Resolving raw.githubusercontent.com... 151.101.72.133
Connecting to raw.githubusercontent.com|151.101.72.133|:443... connected.
ERROR: certificate common name “www.github.com” doesn’t match requested host name “raw.githubusercontent.com”.
To connect to raw.githubusercontent.com insecurely, use ‘--no-check-certificate’.
```