### PR TITLE
fix parse conf bug in bfs_c.cc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ if [ ! -f "${FLAG_DIR}/boost_1_57_0" ] \
     if [ -e boost_1_57_0.tar.gz  ]; then
         rm boost_1_57_0.tar.gz 
     fi 
-    wget https://raw.githubusercontent.com/lylei9/boost_1_57_0/master/boost_1_57_0.tar.gz
+    wget --no-check-certificate https://raw.githubusercontent.com/lylei9/boost_1_57_0/master/boost_1_57_0.tar.gz
     tar zxf boost_1_57_0.tar.gz
     rm -rf ${DEPS_PREFIX}/boost_1_57_0
     mv boost_1_57_0 ${DEPS_PREFIX}/boost_1_57_0

--- a/src/sdk/bfs_c.cc
+++ b/src/sdk/bfs_c.cc
@@ -37,18 +37,19 @@ struct bfs_file_t {
 };
 
 bfs_fs_t* bfs_open_file_system(const char* flag_file) {
-    std::string flag = "--flagfile=";
     if (flag_file) {
-        flag += flag_file;
+        FLAGS_flagfile = flag_file;
     } else {
-        flag += "./bfs.flag";
+        FLAGS_flagfile = "./bfs.flag";    
     }
+
+    // This function google::ParseCommandLineFlags(&argc, &argv, false),
+    // parse the config from the argv[1]. And the argv[0] just use to represent 
+    // a program name, it's not a config parameter.
     int argc = 1;
-    char* file_path = new char[flag.size() + 1];
-    strcpy(file_path, flag.c_str());
-    char** argv = &file_path;
+    char* name = const_cast<char *>("bfs_c.cc");
+    char** argv = &name;
     ::google::ParseCommandLineFlags(&argc, &argv, false);
-    delete[] file_path;
 
     bfs_fs_t* fs = new bfs_fs_t;
     std::string ns_address = FLAGS_nameserver_nodes;


### PR DESCRIPTION
## bug：
bfs_open_file_system()函数中，从flag_file解析配置是不生效的。无论是否指定flag_file,都会从flags.cc中加载配置，并没有从conf文件中加载配置。
原因：gflag的ParseCommandLineFlags()函数是从argv[1]开始解析，argv[0]只是被当做program name
```
// @file: gflags.cc
uint32 CommandLineFlagParser::ParseNewCommandLineFlags(int* argc, char*** argv,
                                                       bool remove_flags) {
  int first_nonopt = *argc;        // for non-options moved to the end

  registry_->Lock();
  for (int i = 1; i < first_nonopt; i++) {
    char* arg = (*argv)[i];
    ...
    ...
}
```
## fix
使用FLAGS_flagfile来指定配置文件，默认配置文件./bfs.flag。 保持原有逻辑，并fix bug.
